### PR TITLE
Change base url to api.close.com

### DIFF
--- a/closeioClient.go
+++ b/closeioClient.go
@@ -627,7 +627,7 @@ func (c HttpCloseIoClient) UpdateAddress(address Address, leadID string) error {
 }
 
 func (c HttpCloseIoClient) getResponse(method, route string, query map[string]string, body io.Reader) ([]byte, error) {
-	req, err := http.NewRequest(method, fmt.Sprintf("https://app.close.io/api/v1/%s/", route), body)
+	req, err := http.NewRequest(method, fmt.Sprintf("https://api.close.com/api/v1/%s/", route), body)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error while creating http request %s", err.Error())


### PR DESCRIPTION
Hey Veyo-care: 

As part of a domain restructuring, we've switched the base url of our api to `api.close.com/api/v1` :) 

`app.close.io/api/v1` will continue to be supported, but it is now deprecated. So, this PR just switches the base url your client uses. 